### PR TITLE
Update broken links to Tableau online help

### DIFF
--- a/pages/05_embedding_in_other_apps.md
+++ b/pages/05_embedding_in_other_apps.md
@@ -16,8 +16,8 @@ You can embed Tableau Online views into Sharepoint as well, but neither Active D
 
 **See also**
 
-* [Documentation for embedding in Sharepoint with Active Directory](http://onlinehelp.tableau.com/current/server/en-us/embed_ex_SP.htm)
-* [Documentation for embedding in Sharepoint with Local Authentication](http://onlinehelp.tableau.com/current/server/en-us/embed_ex_trustedauth.htm)
+* [Documentation for embedding in Sharepoint with Active Directory](https://onlinehelp.tableau.com/current/pro/desktop/en-us/help.htm#embed_ex_SP.html)
+* [Documentation for embedding in Sharepoint with Local Authentication](https://onlinehelp.tableau.com/current/pro/desktop/en-us/help.htm#embed_ex_trustedauth.html)
 
 ##  Embedding into Salesforce Canvas
 


### PR DESCRIPTION
Content was moved from server to desktop help.
These new URLs include the help.htm page so that the TOC will appear.  You can drop the help.htm# part if you don't want that. 
Cheers!
